### PR TITLE
recipe cleanup

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,12 +35,13 @@ test:
     - pip
 
 about:
+  summary: OpenTelemetry Python / Semantic Conventions
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: OpenTelemetry Semantic Conventions
-  doc_url: https://opentelemetry.io
+  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,12 +14,14 @@ build:
   number: 0
   skip: true  # [py<36]
   # noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -38,9 +40,12 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: OpenTelemetry Semantic Conventions
+  doc_url: https://opentelemetry.io
   description: |-
-    This library contains generated code for the semantic conventions
-    defined by the OpenTelemetry specification.
+    OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
+    Observability framework for instrumenting, generating, collecting, and exporting
+    telemetry data such as traces, metrics, logs. As an industry-standard
+    it is natively supported by a number of vendors.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
I'm standardizing the metadata for everything but `summary` and `home` for each of these OpenTelemetry Python recipes because this is a monorepo project. Summary will be specific to the repo, and `home` will point to the subdirectory.