### PR TITLE
Version 0.47b0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-aggregate_check: false
-upload_channels:
-  - sfe1ed40
-  - services
-channels:
-  - sfe1ed40
-  - services

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-aggregate_check: false
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python
@@ -44,6 +47,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
   doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
@@ -52,5 +56,7 @@ about:
     it is natively supported by a number of vendors.
 
 extra:
+  skip-lints:
+    - invalid_url
   recipe-maintainers:
     - mariusvniekerk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,6 @@ about:
   license_file: LICENSE
   doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
-  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,32 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.33b0" %}
-{% set sha256 = "67d62461c87b683b958428ced79162ec4d567dabf30b050f270bbd01eff89ced" %}
+{% set version = "0.47b0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-semantic-conventions-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_semantic_conventions-{{ version }}.tar.gz
+  sha256: a8d57999bbe3495ffd4d510de26a97dadc1dace53e0275001b2c1b2f67992a7e
+  patches:
+    # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
+    - patches/0000-fix-classifier-clash-in-pyproject.patch
+
 
 build:
   number: 0
-  skip: true  # [py<36]
-  # noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - python
+    - opentelemetry-api ==1.26.0
+    - Deprecated >=1.2.6
 
 test:
   imports:
@@ -35,18 +38,18 @@ test:
     - pip
 
 about:
-  home: https://github.com/open-telemetry/opentelemetry-python
   summary: OpenTelemetry Python / Semantic Conventions
-  description: |
+  home: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
+  description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting
     telemetry data such as traces, metrics, logs. As an industry-standard
     it is natively supported by a number of vendors.
-  license: Apache-2.0
-  license_family: Apache
-  license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io
-  dev_url: https://github.com/open-telemetry/opentelemetry-python
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,32 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.33b0" %}
-{% set sha256 = "67d62461c87b683b958428ced79162ec4d567dabf30b050f270bbd01eff89ced" %}
+{% set version = "0.47b0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-semantic-conventions-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_semantic_conventions-{{ version }}.tar.gz
+  sha256: a8d57999bbe3495ffd4d510de26a97dadc1dace53e0275001b2c1b2f67992a7e
+  patches:
+    # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
+    - patches/0000-fix-classifier-clash-in-pyproject.patch
+
 
 build:
   number: 0
-  skip: true  # [py<36]
-  # noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - python
+    - opentelemetry-api ==1.26.0
+    - Deprecated >=1.2.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - opentelemetry-api ==1.26.0
-    - Deprecated >=1.2.6
+    - deprecated >=1.2.6
 
 test:
   imports:
@@ -46,7 +46,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_url: https://opentelemetry-python.readthedocs.io/
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source

--- a/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
+++ b/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
@@ -1,0 +1,10 @@
+--- pyproject.toml	2024-08-27 12:14:39.373221382 +0100
++++ "pyproject copy.toml"	2024-08-27 12:15:59.915901289 +0100
+@@ -14,7 +14,6 @@
+ ]
+ classifiers = [
+   "Development Status :: 5 - Production/Stable",
+-  "Framework :: OpenTelemetry",
+   "Intended Audience :: Developers",
+   "License :: OSI Approved :: Apache Software License",
+   "Programming Language :: Python",


### PR DESCRIPTION
opentelemetry-semantic-conventions 0.47b0

**Destination channel:** defaults

### Links

- [PKG-2424](https://anaconda.atlassian.net/browse/PKG-2424) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions)
- [Upstream changelog/diff](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.26.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- patch issue with classifier
- Hatchling
- sha and version update


[PKG-2424]: https://anaconda.atlassian.net/browse/PKG-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ