### PR TITLE
opentelemetry-semantic-conventions 0.58b0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/opentelemetry-api-feedstock/pr6/44f7e77

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-
+channels:
+  - https://staging.continuum.io/pbp/fs/opentelemetry-api-feedstock/pr6/44f7e77

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.51b0" %}
+{% set version = "0.58b0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_semantic_conventions-{{ version }}.tar.gz
-  sha256: 3fabf47f35d1fd9aebcdca7e6802d86bd5ebc3bc3408b7e3248dde6e87a18c47
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: 6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25
 
 
 build:
   number: 0
-  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -22,17 +22,21 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api ==1.30.0
-    - deprecated >=1.2.6
+    - opentelemetry-api 1.37.0
+    - typing-extensions >=4.5.0
 
 test:
+  source_files:
+    - tests
   imports:
     - opentelemetry
     - opentelemetry.semconv
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   summary: OpenTelemetry Python / Semantic Conventions
@@ -40,9 +44,9 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/
+  doc_url: https://opentelemetry-python.readthedocs.io
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
-  description: |-
+  description: |
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting
     telemetry data such as traces, metrics, logs. As an industry-standard

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25
 
-
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
opentelemetry-semantic-conventions 0.58b0 

**Destination channel:** Defaults

### Links

- [PKG-9800]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/
- conda_forge:    https://github.com/conda-forge/opentelemetry-semantic-conventions-feedstock
- pypi:           https://pypi.org/project/opentelemetry-semantic-conventions/0.58b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-semantic-conventions/0.58b0

### Explanation of changes:

- new version number


[PKG-9800]: https://anaconda.atlassian.net/browse/PKG-9800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ