### PR TITLE
opentelemetry-semantic-conventions 0.59b0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.58b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25
+  sha256: 7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -21,7 +21,7 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api 1.37.0
+    - opentelemetry-api 1.38.0
     - typing-extensions >=4.5.0
 
 test:
@@ -38,18 +38,18 @@ test:
     - pytest
 
 about:
-  summary: OpenTelemetry Python / Semantic Conventions
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io
-  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
+  summary: OpenTelemetry Python / Semantic Conventions
   description: |
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting
     telemetry data such as traces, metrics, logs. As an industry-standard
     it is natively supported by a number of vendors.
+  doc_url: https://opentelemetry-python.readthedocs.io
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
 
 extra:
   skip-lints:


### PR DESCRIPTION
opentelemetry-semantic-conventions 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-10839]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.38.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-semantic-conventions-feedstock
- pypi:           https://pypi.org/project/opentelemetry-semantic-conventions/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-semantic-conventions/0.59b0

### Explanation of changes:

- new version number


[PKG-10839]: https://anaconda.atlassian.net/browse/PKG-10839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ