### PR TITLE
opentelemetry-semantic-conventions 0.61b0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-staging_channel_upload_target: otel-1.40.0-staging
-
-channels:
-  - https://staging.continuum.io/pbp/otel-1.40.0-staging

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+staging_channel_upload_target: otel-1.40.0-staging
+
+channels:
+  - https://staging.continuum.io/pbp/otel-1.40.0-staging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.59b0" %}
+{% set version = "0.61b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0
+  sha256: 072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a
 
 build:
   number: 0
@@ -21,7 +21,7 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api 1.38.0
+    - opentelemetry-api 1.40.0
     - typing-extensions >=4.5.0
 
 test:
@@ -52,7 +52,5 @@ about:
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions
 
 extra:
-  skip-lints:
-    - invalid_url
   recipe-maintainers:
     - mariusvniekerk


### PR DESCRIPTION
opentelemetry-semantic-conventions 0.61b0

**Destination channel:** defaults (via otel-1.40.0-staging during chain build)

### Links

- [PKG-14558](https://anaconda.atlassian.net/browse/PKG-14558)
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074)
- Blocks: [PKG-14486](https://anaconda.atlassian.net/browse/PKG-14486) (pydantic-ai)
- [PyPI release](https://pypi.org/project/opentelemetry-semantic-conventions/0.61b0/)

### Explanation of changes:

- Bump opentelemetry-semantic-conventions 0.59b0 -> 0.61b0 (paired with OTel 1.40.0).
- Tier 2 of the 8-package OTel ecosystem lockstep update.
- **Run dep bump:** `opentelemetry-api 1.38.0` -> `1.40.0` (exact pin per upstream `requires_dist`).
- **abs.yaml:**
  - Added `staging_channel_upload_target: otel-1.40.0-staging` (publish to staging so Tier 3+ can consume).
  - Added `channels: - https://staging.continuum.io/pbp/otel-1.40.0-staging` (consume Tier 1 `opentelemetry-api 1.40.0` from staging since it isn't in defaults yet).
  - Removed deprecated `ANACONDA_ROCKET_ENABLE_PY314: yes` (py3.14 is in aggregate CBC default).
- Recipe cleanup: removed stale `extra.skip-lints: [invalid_url]`.
- Other run deps unchanged: `typing-extensions >=4.5.0` (verified against [PyPI requires_dist](https://pypi.org/pypi/opentelemetry-semantic-conventions/0.61b0/json)).

[PKG-14558]: https://anaconda.atlassian.net/browse/PKG-14558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14486]: https://anaconda.atlassian.net/browse/PKG-14486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ