### PR TITLE
opentelemetry-semantic-conventions 0.60b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953
+  sha256: 227d7aa73cbb8a2e418029d6b6465553aa01cf7e78ec9d0bc3255c7b3ac5bf8f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 227d7aa73cbb8a2e418029d6b6465553aa01cf7e78ec9d0bc3255c7b3ac5bf8f
+  sha256: 87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: d7663a39603df6bb0c49c803cf4d1aa745c27d128d28d3d59c00e66bac919d66
+  sha256: 87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.60b0" %}
+{% set version = "0.60b1" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
opentelemetry-semantic-conventions 0.60b1

**Destination channel:** defaults

### Links

- [PKG-16131](https://anaconda.atlassian.net/browse/PKG-16131) 
- [Upstream repository](https://inspector.pypi.io/project/opentelemetry-semantic-conventions/0.60b1/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz/)



[PKG-16131]: https://anaconda.atlassian.net/browse/PKG-16131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ