### PR TITLE
opentelemetry-semantic-conventions 1.43.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "opentelemetry-semantic-conventions" %}
-{% set version = "0.61b0" %}
+{% set version = "0.64b0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a
+  sha256: 72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c
 
 build:
   number: 0
-  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -21,7 +21,7 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api 1.40.0
+    - opentelemetry-api ==1.43.0
     - typing-extensions >=4.5.0
 
 test:


### PR DESCRIPTION
opentelemetry-semantic-conventions 1.43.0 

**Destination channel:** Defaults

### Links

- [PKG-16289]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.43.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-semantic-conventions-feedstock
- pypi:           https://pypi.org/project/opentelemetry-semantic-conventions/0.64b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-semantic-conventions/0.64b0

### Explanation of changes:

- new version number


[PKG-16289]: https://anaconda.atlassian.net/browse/PKG-16289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ